### PR TITLE
Fixing 2 compilation issues in SRC and SDK

### DIFF
--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -1797,7 +1797,7 @@ u_result RPlidarDriverImplCommon::grabScanData(rplidar_response_measurement_node
 {
     DEPRECATED_WARN("grabScanData()", "grabScanDataHq()");
 
-    switch (_dataEvt.wait(timeout))
+    switch (static_cast<int>(_dataEvt.wait(timeout)))
     {
     case rp::hal::Event::EVENT_TIMEOUT:
         count = 0;
@@ -1826,7 +1826,7 @@ u_result RPlidarDriverImplCommon::grabScanData(rplidar_response_measurement_node
 
 u_result RPlidarDriverImplCommon::grabScanDataHq(rplidar_response_measurement_node_hq_t * nodebuffer, size_t & count, _u32 timeout)
 {
-    switch (_dataEvt.wait(timeout))
+    switch (static_cast<int>(_dataEvt.wait(timeout)))
     {
     case rp::hal::Event::EVENT_TIMEOUT:
         count = 0;

--- a/src/rplidar_scan_publisher.cpp
+++ b/src/rplidar_scan_publisher.cpp
@@ -64,15 +64,15 @@ class RPLidarScanPublisher : public rclcpp::Node
   private:    
     void init_param()
     {
-        this->declare_parameter("channel_type");
-        this->declare_parameter("tcp_ip");
-        this->declare_parameter("tcp_port");
-        this->declare_parameter("serial_port");
-        this->declare_parameter("serial_baudrate");
-        this->declare_parameter("frame_id");
-        this->declare_parameter("inverted");
-        this->declare_parameter("angle_compensate");
-        this->declare_parameter("scan_mode");
+        this->declare_parameter<std::string>("channel_type");
+        this->declare_parameter<std::string>("tcp_ip");
+        this->declare_parameter<int>("tcp_port");
+        this->declare_parameter<std::string>("serial_port");
+        this->declare_parameter<int>("serial_baudrate");
+        this->declare_parameter<std::string>("frame_id");
+        this->declare_parameter<bool>("inverted");
+        this->declare_parameter<bool>("angle_compensate");
+        this->declare_parameter<std::string>("scan_mode");
 
         this->get_parameter_or<std::string>("channel_type", channel_type, "serial");
         this->get_parameter_or<std::string>("tcp_ip", tcp_ip, "192.168.0.7"); 


### PR DESCRIPTION
Fixing two compile issues (on Ubuntu 22.04 running ROS2 Humble)
 - added missing type's from the "this->declare_parameter" functions in the initialisation section of the file 'rplidar_scan_publisher.cpp'
 - fixed "narrowing conversion of 'rp::hal::Event::EVENT_TIMEOUT' from 'int' to 'long unsigned int'" error messages by type-casting to an 'int'